### PR TITLE
Fix active_record.rb to follow the change of AR after 5.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.1.5
+
+- Fix active_record.rb to follow the change of AR after 5.2.
+
 ### v0.1.4
 
 - Add Charwidth.to_full_width

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,54 +1,55 @@
 PATH
   remote: .
   specs:
-    charwidth (0.1.3)
+    charwidth (0.1.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.1.0)
-      activesupport (= 5.1.0)
-    activerecord (5.1.0)
-      activemodel (= 5.1.0)
-      activesupport (= 5.1.0)
-      arel (~> 8.0)
-    activesupport (5.1.0)
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activerecord (5.2.2)
+      activemodel (= 5.2.2)
+      activesupport (= 5.2.2)
+      arel (>= 9.0)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (8.0.0)
-    concurrent-ruby (1.0.5)
+    arel (9.0.0)
+    concurrent-ruby (1.1.4)
     diff-lcs (1.3)
-    docile (1.1.5)
-    i18n (0.8.1)
-    json (2.1.0)
-    minitest (5.10.1)
-    rake (12.0.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    docile (1.3.1)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    json (2.2.0)
+    minitest (5.11.3)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
+      rspec-support (~> 3.8.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.5.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
-    simplecov (0.14.1)
-      docile (~> 1.1.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.2)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -62,7 +63,7 @@ DEPENDENCIES
   rspec
   rspec-its
   simplecov
-  sqlite3
+  sqlite3 (< 1.4)
 
 BUNDLED WITH
-   1.14.4
+   1.17.2

--- a/charwidth.gemspec
+++ b/charwidth.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "activerecord", ">= 3"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "< 1.4"
 end

--- a/lib/charwidth/active_record.rb
+++ b/lib/charwidth/active_record.rb
@@ -12,8 +12,13 @@ module Charwidth
     def self.included(base)
       base.class_eval do
         include InstanceMethods
-        alias_method :write_attribute_without_normalize_charwidth, :write_attribute
-        alias_method :write_attribute, :write_attribute_with_normalize_charwidth
+        if ::ActiveRecord.version<Gem::Version.new("5.2")
+          alias_method :write_attribute_without_normalize_charwidth, :write_attribute
+          alias_method :write_attribute, :write_attribute_with_normalize_charwidth
+        else
+          alias_method :write_attribute_without_normalize_charwidth, :_write_attribute
+          alias_method :_write_attribute, :write_attribute_with_normalize_charwidth
+        end
       end
     end
   end

--- a/lib/charwidth/version.rb
+++ b/lib/charwidth/version.rb
@@ -1,3 +1,3 @@
 module Charwidth
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
In the ActiveRecord integration, it makes aliases to make hook around ActiveRecord::AttributeMethods:Write#write_attribute to work.  After 5.2 of AR, AR uses ActiveRecord::AttributeMethods:Write#_write_attribute when it creates or updates objects' attributes.  This change breaks the charwidth active_record integration.  This PR fixes it.

Sorry for making dirty Gemfile.lock and so on.
