### PR TITLE
exclude development commands from deliverables

### DIFF
--- a/charwidth.gemspec
+++ b/charwidth.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r(^bin/)) {|f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r(^bin/charwidth)) {|f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Hi, thank you for maintenance.

The following warnings occur for charwidth v0.2.0 and rubocop or rspec users. This is because the charwidth artifacts include executable files for development, such as rubocop and rspec.

```
The `rubocop` executable in the `charwidth` gem is being loaded, but it's also present in other gems (rubocop).
If you meant to run the executable for another gem, make sure you use a project specific binstub (`bundle binstub <gem_name>`).
If you plan to use multiple conflicting executables, generate binstubs for them and disambiguate their names.
The `rubocop` executable in the `rubocop` gem is being loaded, but it's also present in other gems (charwidth).
If you meant to run the executable for another gem, make sure you use a project specific binstub (`bundle binstub <gem_name>`).
If you plan to use multiple conflicting executables, generate binstubs for them and disambiguate their names.
```

## Reproduction


```Gemfile
source "https://rubygems.org"

git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

gem "rubocop"
gem "charwidth", "0.2.0"
```

```command
bundle install
bundle binstub rubocop
bundle exec rubocop
```